### PR TITLE
Jesse's late Christmas gift

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Commands:
 ### Preparing the host
 
 The remote host can optionally be prepared manually to run CUDA builds.
-This is done automatically by the `build` subcommand, so in a normal workflow it isn't needed.
+This is done automatically by the `build` command, so in a normal workflow it isn't needed.
 
-The `prepare` subcommand will create a work directory, set up Conda, and create a Conda environment.
+The `prepare` command will create a work directory, set up Conda, and create a Conda environment.
 On Windows, it will also install CUDA software and drivers, which takes more time.
 This only needs to be done once.
 
@@ -180,7 +180,7 @@ For example, if the URL is `https://github.com/AnacondaRecipes/llama.cpp-feedsto
 
 Sisyphus will prepare the host to run CUDA builds if needed, prepare all the data locally, upload it to the host, start the build, then show the build process in real-time (unless `--no-watch` is specified).
 
-If you lose connection to the host during the build process, which isn't unusual, you can use the `watch` command like bellow to resume watching the build process. Losing the connection will never interrupt builds.
+If you lose connection to the host during the build process, which isn't unusual, you can use the `watch` command like below to resume watching the build process. Losing the connection will never interrupt builds.
 
 
 ### Watching the build process
@@ -197,6 +197,51 @@ On the default logging level sisyphus will show the build output in real-time.
 Here too, an exit code will be returned at the end for use in automation.
 
 
+### Check build status
+
+```
+> sisyphus status --help
+Usage: sisyphus status [OPTIONS]
+
+  Print the build status.
+
+Options:
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
+  -P, --package TEXT              Name of the package being built.  [required]
+  -l, --log-level [error|warning|info|debug]
+                                  Logging level.  [default: info]
+  -h, --help                      Show this message and exit.
+```
+
+This will print one of the following statuses:
+- `Not started`: The build hasn't started yet
+- `Building`: The build is currently running
+- `Complete`: The build finished successfully
+- `Failed`: The build failed
+
+The command returns immediately without waiting for the build to finish.
+
+
+### Wait for build completion
+
+```
+> sisyphus wait --help
+Usage: sisyphus wait [OPTIONS]
+
+  Wait for the build to finish and set exit code based on result.
+
+Options:
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
+  -P, --package TEXT              Name of the package being built.  [required]
+  -l, --log-level [error|warning|info|debug]
+                                  Logging level.  [default: info]
+  -h, --help                      Show this message and exit.
+```
+
+This command will wait for the build to finish and return an exit code of 0 if the build succeeded, or 1 if it failed.
+This is useful for automation and scripting.
+
+
 ### Print or download the build log
 
 ```
@@ -208,12 +253,13 @@ Usage: sisyphus log [OPTIONS]
 Options:
   -H, --host TEXT                 IP or FQDN of the build host.  [required]
   -P, --package TEXT              Name of the package being built.  [required]
+  --no-wait                       Don't wait for the build to finish before printing the log.
   -l, --log-level [error|warning|info|debug]
                                   Logging level.  [default: info]
   -h, --help                      Show this message and exit.
 ```
 
-This will print the build log in your terminal.
+This will print the build log in your terminal. By default, it will wait for the build to finish before printing the log, unless `--no-wait` is specified.
 The output can be piped to a pager like `less` or be redirected to a file to save it.
 
 
@@ -223,7 +269,7 @@ The output can be piped to a pager like `less` or be redirected to a file to sav
 ❯ sisyphus download --help
 Usage: sisyphus download [OPTIONS]
 
-  Download built tarballs.
+  Download built packages from the remote host.
 
 Options:
   -H, --host TEXT                 IP or FQDN of the build host.  [required]
@@ -249,7 +295,7 @@ sisyphus download -H <host> -P <package>
 > sisyphus upload --help
 Usage: sisyphus upload [OPTIONS]
 
-  Upload build packages to anaconda.org.
+  Upload built packages on the remote host to anaconda.org.
 
 Options:
   -H, --host TEXT                 IP or FQDN of the build host.  [required]

--- a/README.md
+++ b/README.md
@@ -274,6 +274,29 @@ sisyphus upload -H <host> -P <package> -C <channel> -T <token>
 > https://github.com/anaconda-distribution/rocket-platform/actions/workflows/codesign-windows.yml
 
 
+### Transmute packages
+
+```
+> sisyphus transmute --help
+Usage: sisyphus transmute [OPTIONS]
+
+  Transmute .tar.bz2 packages to .conda packages.
+
+Options:
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
+  -P, --package TEXT              Name of the package being built.  [required]
+  -l, --log-level [error|warning|info|debug]
+                                  Logging level.  [default: info]
+  -h, --help                      Show this message and exit.
+```
+
+Transmute packages with:
+
+```
+sisyphus transmute -H <host> -P <package>
+```
+
+
 [1]: https://github.com/anaconda-distribution/rocket-platform/tree/main/machine-images#dev-instances
 [2]: https://github.com/anaconda-distribution/rocket-platform/actions/workflows/start.yml
 [3]: https://github.com/anaconda-distribution/perseverance-skills/blob/main/sections/02_Package_building/01_How_tos/Building_GPU_packages.md

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Options:
   -P, --package TEXT              Name of the package to build  [required]
   -B, --branch TEXT               Branch to build from in the feedstock's
                                   repository
+  --no-watch                      Don't watch the build process after it starts
   -l, --log-level [error|warning|info|debug]
                                   Logging level  [default: info]
   -h, --help                      Show this message and exit.
@@ -177,7 +178,7 @@ Start the build with:
 `<package>` is the package name as written in the URL for the feedstock.
 For example, if the URL is `https://github.com/AnacondaRecipes/llama.cpp-feedstock`, then `<package>` is `llama.cpp`.
 
-Sisyphus will prepare the host to run CUDA builds if needed, prepare all the data locally, upload it to the host, start the build, then show the build process in real-time.
+Sisyphus will prepare the host to run CUDA builds if needed, prepare all the data locally, upload it to the host, start the build, then show the build process in real-time (unless `--no-watch` is specified).
 
 If you lose connection to the host during the build process, which isn't unusual, you can use the `watch` command like bellow to resume watching the build process. Losing the connection will never interrupt builds.
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ Options:
 
 Commands:
   build     Build a package on the host.
-  download  Download built tarballs.
+  download  Download built packages from the remote host.
   log       Print build log to standard output (does not update in real-time).
   prepare   Prepare the host for building.
-  upload    Upload built packages to anaconda.org.
+  status    Print the build status.
+  transmute Transmute .tar.bz2 packages to .conda packages.
+  upload    Upload built packages on the remote host to anaconda.org.
+  wait      Wait for the build to finish and set exit code based on result.
   watch     Watch build in real-time if a package name is passed, otherwise watch the prepare process.
 ```
 
@@ -96,9 +99,9 @@ Usage: sisyphus prepare [OPTIONS]
   Prepare the host for building.
 
 Options:
-  -H, --host TEXT                 IP or FQDN of the build host  [required]
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
   -l, --log-level [error|warning|info|debug]
-                                  Logging level  [default: info]
+                                  Logging level.  [default: info]
   -h, --help                      Show this message and exit.
 ```
 
@@ -133,10 +136,10 @@ Usage: sisyphus watch [OPTIONS]
   prepare process. Set exit code on error.
 
 Options:
-  -H, --host TEXT                 IP or FQDN of the build host  [required]
-  -P, --package TEXT              Name of the package being built
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
+  -P, --package TEXT              Name of the package being built.
   -l, --log-level [error|warning|info|debug]
-                                  Logging level  [default: info]
+                                  Logging level.  [default: info]
   -h, --help                      Show this message and exit.
 ```
 
@@ -159,13 +162,13 @@ Usage: sisyphus build [OPTIONS]
   Build a package on the host.
 
 Options:
-  -H, --host TEXT                 IP or FQDN of the build host  [required]
-  -P, --package TEXT              Name of the package to build  [required]
+  -H, --host TEXT                 IP or FQDN of the build host.  [required]
+  -P, --package TEXT              Name of the package to build.  [required]
   -B, --branch TEXT               Branch to build from in the feedstock's
-                                  repository
-  --no-watch                      Don't watch the build process after it starts
+                                  repository.
+  --no-watch                      Don't watch the build process after it starts.
   -l, --log-level [error|warning|info|debug]
-                                  Logging level  [default: info]
+                                  Logging level.  [default: info]
   -h, --help                      Show this message and exit.
 ```
 
@@ -245,7 +248,7 @@ This is useful for automation and scripting.
 ### Print or download the build log
 
 ```
-❯ sisyphus log --help
+> sisyphus log --help
 Usage: sisyphus log [OPTIONS]
 
   Print build log to standard output (does not update in real-time).
@@ -266,7 +269,7 @@ The output can be piped to a pager like `less` or be redirected to a file to sav
 ### Download built packages
 
 ```
-❯ sisyphus download --help
+> sisyphus download --help
 Usage: sisyphus download [OPTIONS]
 
   Download built packages from the remote host.
@@ -275,8 +278,7 @@ Options:
   -H, --host TEXT                 IP or FQDN of the build host.  [required]
   -P, --package TEXT              Name of the package being built.  [required]
   -d, --destination TEXT          Destination directory.
-  -a, --all                       Download the whole work directory for
-                                  debugging.
+  -a, --all                       Download the whole work directory for debugging.
   -l, --log-level [error|warning|info|debug]
                                   Logging level.  [default: info]
   -h, --help                      Show this message and exit.

--- a/sisyphus/build.py
+++ b/sisyphus/build.py
@@ -94,5 +94,5 @@ class Build:
 
         # Finally upload the data to the host
         # We're doing it from within this method because the temporary directory is very volatile
-        host.put(self.tarfile, host.topdir)
+        host.put(self.tarfile, host.sisyphus_dir)
         logging.info("Data archive uploaded")

--- a/sisyphus/host.py
+++ b/sisyphus/host.py
@@ -12,8 +12,8 @@ LINUX_TYPE = "linux"
 WINDOWS_TYPE = "windows"
 LINUX_USER = "ec2-user"
 WINDOWS_USER = "dev-admin"
-LINUX_TOPDIR = "/tmp/sisyphus"
-WINDOWS_TOPDIR = "\\sisyphus"
+LINUX_TOPDIR = "/tmp"
+WINDOWS_TOPDIR = "\\"
 CONDA_PACKAGES = "conda-build distro-tooling::anaconda-linter git anaconda-client conda-package-handling"
 BUILD_OPTIONS = "--error-overlinking -c ai-staging"
 ACTIVATE = "conda activate sisyphus &&"
@@ -33,6 +33,7 @@ class Host:
             self.topdir = LINUX_TOPDIR
             self.touch = "touch"
             self.run("conda init")
+            self.pkgdir = "linux-64"
         elif self.__test_connection(WINDOWS_USER, "ver", WINDOWS_TYPE):
             self.type = WINDOWS_TYPE
             self.user = WINDOWS_USER
@@ -40,10 +41,12 @@ class Host:
             self.topdir = WINDOWS_TOPDIR
             self.touch = "copy nul"
             self.run("C:\\miniconda3\\Scripts\\conda.exe init")
+            self.pkgdir = "win-64"
         else:
             logging.error("Couldn't connect to host '%s' or figure out what type it is", self.host)
             raise SystemExit(1)
-        self.mkdir(self.topdir)
+        self.sisyphus_dir = self.topdir + self.separator + "sisyphus"
+        self.mkdir(self.sisyphus_dir)
 
 
     def __test_connection(self, user, cmd, type):
@@ -62,6 +65,20 @@ class Host:
             logging.debug(r.stdout.lstrip().rstrip())
             logging.info("'%s' is a %s host", self.host, type.capitalize())
             return True
+
+
+    def path_join(self, *paths):
+        """
+        Join paths with the host separator.
+        """
+        return self.separator.join(list(paths))
+
+
+    def path(self, *paths):
+        """
+        Build a path on the host from the Sisyphus directory and the given paths.
+        """
+        return self.separator.join([self.sisyphus_dir] + list(paths))
 
 
     def run(self, cmd, quiet=False):
@@ -180,11 +197,11 @@ class Host:
         Prepare the remote host for building.
         """
         # Create the top-level work directory
-        self.mkdir(self.topdir)
+        self.mkdir(self.sisyphus_dir)
 
         # Does the sisyphus environment exist?
         found = False
-        touch = f"{self.touch} {self.topdir}{self.separator}conda."
+        touch = f"{self.touch} {self.path("conda.")}"
         r = self.run("conda env list")
         for line in r.splitlines():
             if line.startswith("sisyphus "):
@@ -196,22 +213,22 @@ class Host:
         else:
             # It doesn't, so let's create it
             conda_cmd = f"conda create -y -n sisyphus {CONDA_PACKAGES}"
-            redirect = f"{self.topdir}{self.separator}conda.log 2>&1"
+            redirect = f"{self.path("conda.log")} 2>&1"
             self.run_async(f"{conda_cmd} > {redirect} && {touch}ready || {touch}failed")
             logging.info("Environment 'sisyphus' is being created")
 
         # Windows hosts need to have CUDA installed by the user
         if self.type == WINDOWS_TYPE:
-            if self.exists(f"{self.topdir}{self.separator}cuda_driver.log") or self.exists(f"{self.topdir}{self.separator}cuda_12.3.0.log"):
+            if self.exists(self.path("cuda_driver.log")) or self.exists(self.path("cuda_12.3.0.log")):
                 logging.info("CUDA is already installed or being installed")
             else:
                 # Using multiple powershell calls from cmd because the && operator doesn't exist in the old version we're using
                 start = "powershell -ExecutionPolicy ByPass -File \\prefect\\install_"
-                middle = f".ps1 > {self.topdir}\\"
+                middle = f".ps1 > {self.sisyphus_dir}\\"
                 end = ".log 2>&1"
                 cuda_driver = f"{start}cuda_driver{middle}cuda_driver{end}"
                 cuda_12_3_0 = f"{start}cuda_12.3.0{middle}cuda_12.3.0{end}"
-                touch = f"{self.touch} {self.topdir}{self.separator}cuda."
+                touch = f"{self.touch} {self.path("cuda.")}"
                 self.run_async(f"{cuda_driver} && {cuda_12_3_0} && {touch}ready || {touch}failed")
                 logging.info("CUDA is being installed")
 
@@ -231,12 +248,12 @@ class Host:
         """
         Build a feedstock with the conda config both in a remote directory.
         """
-        builddir = f"{workdir}{self.separator}build"
-        cbc = f"{workdir}{self.separator}conda_build_config.yaml"
-        feedstock = f"{workdir}{self.separator}feedstock"
-        logfile = f"{workdir}{self.separator}build.log"
+        builddir = self.path_join(workdir, "build")
+        cbc = self.path_join(workdir, "conda_build_config.yaml")
+        feedstock = self.path_join(workdir, "feedstock")
+        logfile = self.path_join(workdir, "build.log")
         cmd = f"conda build {BUILD_OPTIONS} -e {cbc} --croot={builddir} {feedstock}"
-        touch = f"{self.touch} {workdir}{self.separator}build."
+        touch = f"{self.touch} {self.path_join(workdir, "build.")}"
         self.mkdir(builddir)
         self.run_async(f"{ACTIVATE} {cmd} > {logfile} 2>&1 && {touch}ready || {touch}failed")
         logging.info("Build is running")
@@ -251,7 +268,7 @@ class Host:
         # Avoid overflowing the fabric connection
         max_lines = 1000
 
-        logfile = f"{workdir}{self.separator}build.log"
+        logfile = self.path_join(workdir, "build.log")
         if self.type == LINUX_TYPE:
             skip_pre = 'tail -n +'
             skip_post = f' "{logfile}" | tail -n {max_lines}'
@@ -267,10 +284,10 @@ class Host:
                 logging.info(line)
             lines_read += len(lines)
             # Quit watching when the build.ready or build.failed files show up
-            if self.exists(f"{workdir}{self.separator}build.ready"):
+            if self.exists(self.path_join(workdir, "build.ready")):
                 logging.info("Build complete")
                 break
-            if self.exists(f"{workdir}{self.separator}build.failed"):
+            if self.exists(self.path_join(workdir, "build.failed")):
                 logging.error("Build Failed")
                 raise SystemExit(1)
             time.sleep(wait)
@@ -286,10 +303,10 @@ class Host:
         error = False
         messaged = False
         while True:
-            if self.exists(self.topdir + self.separator + "conda.ready"):
+            if self.exists(self.path("conda.ready")):
                 logging.info("Conda is ready")
                 break
-            elif self.exists(self.topdir + self.separator + "conda.failed"):
+            elif self.exists(self.path("conda.failed")):
                 logging.warning("Conda setup failed")
                 error = True
                 break
@@ -301,10 +318,10 @@ class Host:
         if self.type == WINDOWS_TYPE:
             messaged = False
             while True:
-                if self.exists(self.topdir + "\\cuda.ready"):
+                if self.exists(self.path("cuda.ready")):
                     logging.info("CUDA is ready")
                     break
-                elif self.exists(self.topdir + "\\cuda.failed"):
+                elif self.exists(self.path("cuda.failed")):
                     logging.warning("CUDA installation failed")
                     error = True
                     break
@@ -321,11 +338,7 @@ class Host:
         """
         Upload build packages to anaconda.org.
         """
-        pkgdir = f"{self.topdir}{self.separator}{package}{self.separator}build{self.separator}"
-        if self.type == LINUX_TYPE:
-            pkgdir = f"{pkgdir}linux-64"
-        elif self.type == WINDOWS_TYPE:
-            pkgdir = f"{pkgdir}win-64"
+        pkgdir = self.path(package, "build", self.pkgdir)
         logging.info("Uploading packages in: %s", pkgdir)
         logging.info("To channel: %s", channel)
         r = self.connection.run(f"{ACTIVATE} anaconda -t {token} upload -c {channel} --force {pkgdir}{self.separator}*.tar.bz2")
@@ -336,11 +349,11 @@ class Host:
         """
         Print the build status.
         """
-        if self.exists(f"{self.topdir}{self.separator}{package}{self.separator}build.ready"):
+        if self.exists(self.path(package, "build.ready")):
             return "Complete"
-        if self.exists(f"{self.topdir}{self.separator}{package}{self.separator}build.failed"):
+        if self.exists(self.path(package, "build.failed")):
             return "Failed"
-        if self.exists(f"{self.topdir}{self.separator}{package}{self.separator}build.log"):
+        if self.exists(self.path(package, "build.log")):
             return "Building"
         return "Not started"
 
@@ -351,10 +364,10 @@ class Host:
         """
         wait = 60
         while True:
-            if self.exists(f"{self.topdir}{self.separator}{package}{self.separator}build.ready"):
+            if self.exists(self.path(package, "build.ready")):
                 logging.info("Build complete")
                 return True
-            if self.exists(f"{self.topdir}{self.separator}{package}{self.separator}build.failed"):
+            if self.exists(self.path(package, "build.failed")):
                 logging.info("Build failed")
                 return False
             logging.info("Waiting for the build to finish")
@@ -373,7 +386,7 @@ class Host:
         if not no_wait:
             self.wait(package)
 
-        logfile = f"{self.topdir}{self.separator}{package}{self.separator}build.log"
+        logfile = self.path(package, "build.log")
         if self.type == LINUX_TYPE:
             cat = "cat"
         elif self.type == WINDOWS_TYPE:
@@ -392,23 +405,18 @@ class Host:
         # Transmute packages if needed
         self.transmute(package)
 
-        builddir = f"{self.topdir}{self.separator}{package}{self.separator}build"
-        if self.type == LINUX_TYPE:
-            pkgdir = "linux-64"
-            tf = "/tmp/sisyphus.tar"
-        elif self.type == WINDOWS_TYPE:
-            pkgdir = "win-64"
-            tf = "\\sisyphus.tar"
-        logging.info("Downloading package tarballs in '%s%s%s'", builddir, self.separator, pkgdir)
+        builddir = self.path(package, "build")
+        tf = self.topdir + self.separator + "sisyphus.tar"
+        logging.info("Downloading package tarballs in '%s%s%s'", builddir, self.separator, self.pkgdir)
 
         # Create a tarball containing either just packages or the whole build directory
         if all:
-            self.run(f"cd {self.topdir} && cd .. && tar -cf {tf} sisyphus")
+            self.run(f"cd {self.sisyphus_dir} && cd .. && tar -cf {tf} sisyphus")
         else:
             if self.type == LINUX_TYPE:
-                self.run(f"cd {builddir} && tar -cf {tf} {pkgdir}/*.conda {pkgdir}/*.tar.bz2 2>/dev/null || true")
+                self.run(f"cd {builddir} && tar -cf {tf} {self.pkgdir}/*.conda {self.pkgdir}/*.tar.bz2 2>/dev/null || true")
             elif self.type == WINDOWS_TYPE:
-                self.run(f'cd {builddir} && tar -cf {tf} $(dir /s {pkgdir}\\*.conda {pkgdir}\\*.tar.bz2 2>nul )', quiet=True)
+                self.run(f'cd {builddir} && tar -cf {tf} $(dir /s {self.pkgdir}\\*.conda {self.pkgdir}\\*.tar.bz2 2>nul )', quiet=True)
 
         # Download and untar it
         dest = os.path.join(destination, package)
@@ -441,14 +449,10 @@ class Host:
         """
         Transmute .tar.bz2 packages to .conda packages.
         """
-        pkgdir = f"{self.topdir}{self.separator}{package}{self.separator}build{self.separator}"
-        if self.type == LINUX_TYPE:
-            pkgdir += "linux-64"
-        elif self.type == WINDOWS_TYPE:
-            pkgdir += "win-64"
+        pkgdir = self.path(package, "build", self.pkgdir)
         bz2 = [p for p in self.ls(pkgdir) if p.endswith(".tar.bz2")]
         for pkg in bz2:
-            if self.exists(re.sub("tar.bz2", "conda", f"{pkgdir}{self.separator}{pkg}")):
+            if self.exists(re.sub("tar.bz2", "conda", self.path_join(pkgdir, pkg))):
                 logging.info("%s already transmuted", pkg)
             else:
                 logging.info("Transmuting %s", pkg)

--- a/sisyphus/main.py
+++ b/sisyphus/main.py
@@ -168,5 +168,20 @@ def download(host, package, destination, all, log_level):
     h.download(package, destination, all)
 
 
+@cli.command(context_settings=HELP_CONTEXT)
+@click.option("-H", "--host", required=True, help="IP or FQDN of the build host.")
+@click.option("-P", "--package", required=True, help="Name of the package being built.")
+@click.option("-l", "--log-level", type=click.Choice(["error", "warning", "info", "debug"], case_sensitive=False),
+              default="info", show_default=True, help="Logging level.")
+def transmute(host, package, log_level):
+    """
+    Transmute .tar.bz2 packages to .conda packages.
+    """
+    setup_logging(log_level)
+
+    h = Host(host)
+    h.transmute(package)
+
+
 if __name__ == "__main__":
     cli()

--- a/sisyphus/main.py
+++ b/sisyphus/main.py
@@ -79,8 +79,8 @@ def build(package, branch, host, no_watch, log_level):
     # Prepare and upload the data to the host
     b = Build(package, branch)
     b.upload_data(h)
-    workdir = h.topdir + h.separator + package
-    tarfile = h.topdir + h.separator + b.tarfile
+    workdir = h.path(package)
+    tarfile = h.path(b.tarfile)
     # Start from a blank slate, untar the data and cleanup
     h.rm(workdir)
     h.untar(tarfile, workdir)
@@ -112,7 +112,7 @@ def watch(host, package, log_level):
 
     h = Host(host)
     if package:
-        h.watch_build(h.topdir + h.separator + package)
+        h.watch_build(h.path(package))
     else:
         h.watch_prepare()
 

--- a/sisyphus/main.py
+++ b/sisyphus/main.py
@@ -126,7 +126,7 @@ def watch(host, package, log_level):
               default="info", show_default=True, help="Logging level.")
 def upload(host, package, channel, token, log_level):
     """
-    Upload built packages to anaconda.org.
+    Upload built packages on the remote host to anaconda.org.
     """
     setup_logging(log_level)
 
@@ -137,16 +137,17 @@ def upload(host, package, channel, token, log_level):
 @cli.command(context_settings=HELP_CONTEXT)
 @click.option("-H", "--host", required=True, help="IP or FQDN of the build host.")
 @click.option("-P", "--package", required=True, help="Name of the package being built.")
+@click.option("--no-wait", is_flag=True, default=False, help="Don't wait for the build to finish before printing the log.")
 @click.option("-l", "--log-level", type=click.Choice(["error", "warning", "info", "debug"], case_sensitive=False),
               default="info", show_default=True, help="Logging level.")
-def log(host, package, log_level):
+def log(host, package, no_wait, log_level):
     """
-    Print build log to standard output (does not update in real-time).
+    Print the build log to standard output (does not update in real-time).
     """
     setup_logging(log_level)
 
     h = Host(host)
-    h.log(package)
+    h.log(package, no_wait)
 
 
 @cli.command(context_settings=HELP_CONTEXT)
@@ -158,7 +159,7 @@ def log(host, package, log_level):
               default="info", show_default=True, help="Logging level.")
 def download(host, package, destination, all, log_level):
     """
-    Download built tarballs.
+    Download built packages from the remote host.
     """
     setup_logging(log_level)
 
@@ -183,6 +184,37 @@ def transmute(host, package, log_level):
 
     h = Host(host)
     h.transmute(package)
+
+
+@cli.command(context_settings=HELP_CONTEXT)
+@click.option("-H", "--host", required=True, help="IP or FQDN of the build host.")
+@click.option("-P", "--package", required=True, help="Name of the package being built.")
+@click.option("-l", "--log-level", type=click.Choice(["error", "warning", "info", "debug"], case_sensitive=False),
+              default="info", show_default=True, help="Logging level.")
+def status(host, package, log_level):
+    """
+    Print the build status.
+    """
+    setup_logging(log_level)
+
+    h = Host(host)
+    print(h.status(package))
+
+
+@cli.command(context_settings=HELP_CONTEXT)
+@click.option("-H", "--host", required=True, help="IP or FQDN of the build host.")
+@click.option("-P", "--package", required=True, help="Name of the package being built.")
+@click.option("-l", "--log-level", type=click.Choice(["error", "warning", "info", "debug"], case_sensitive=False),
+              default="info", show_default=True, help="Logging level.")
+def wait(host, package, log_level):
+    """
+    Wait for the build to finish and set exit code based on result.
+    """
+    setup_logging(log_level)
+
+    h = Host(host)
+    if not h.wait(package):
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/sisyphus/main.py
+++ b/sisyphus/main.py
@@ -61,9 +61,10 @@ def prepare(host, log_level):
 @click.option("-H", "--host", required=True, help="IP or FQDN of the build host.")
 @click.option("-P", "--package", required=True, help="Name of the package to build.")
 @click.option("-B", "--branch", help="Branch to build from in the feedstock's repository.")
+@click.option("--no-watch", is_flag=True, default=False, help="Don't watch the build process after it starts.")
 @click.option("-l", "--log-level", type=click.Choice(["error", "warning", "info", "debug"], case_sensitive=False),
               default="info", show_default=True, help="Logging level.")
-def build(package, branch, host, log_level):
+def build(package, branch, host, no_watch, log_level):
     """
     Build a package on the host.
     """
@@ -92,8 +93,9 @@ def build(package, branch, host, log_level):
     # Create a build directory, and build the package
     h.build(workdir)
 
-    # Start watching the build process
-    h.watch_build(workdir)
+    # Start watching the build process if not disabled
+    if not no_watch:
+        h.watch_build(workdir)
 
 
 @cli.command(context_settings=HELP_CONTEXT)


### PR DESCRIPTION
This must be merged after https://github.com/anaconda/sisyphus/pull/6

- The `build `command now has a `--no-watch` option which makes it exit as soon as the build is started
- The `log` command now waits for the build to finish to print to standard output, but also has a `--no-wait` option
- There's a `wait` command which waits for the build to finish and sets the exit code to 0 if it succeeds and 1 if it fails
- The `wait` command should be reliable to use even on extremely long builds (i.e. it won't lose the connection to the remote host)
- There's a `status` command which prints either "Not started", "Building", "Complete" or "Failed" to standard output
- Much... cleaner... code