### PR TITLE
Fix windows download path issues

### DIFF
--- a/sisyphus/host.py
+++ b/sisyphus/host.py
@@ -423,7 +423,7 @@ class Host:
             tf = self.path_join(builddir, "sisyphus.tar")
         else:
             tf = self.topdir + self.separator + "sisyphus.tar"
-            
+
         logging.info("Downloading package tarballs in '%s%s%s'", builddir, self.separator, self.pkgdir)
 
         # Create a tarball containing either just packages or the whole build directory
@@ -436,7 +436,7 @@ class Host:
                 elif self.type == WINDOWS_TYPE:
                     # First get the list of files - make sure we're in builddir first
                     files = self.run(f'cd {builddir} && dir /b /s {self.pkgdir}\\*.conda {self.pkgdir}\\*.tar.bz2 2>nul', quiet=True)
-                    
+
                     if not files:
                         logging.warning("No package files found to tar")
                         self.run(f'cd {builddir} && tar -cf "{tf}" --files-from NUL', quiet=True)
@@ -444,14 +444,14 @@ class Host:
                         # Create file list - strip builddir prefix since we'll cd there
                         file_list = " ".join(f'"{f.replace(builddir + "\\", "")}"' for f in files.splitlines())
                         self.run(f'cd {builddir} && tar -cf "{tf}" {file_list}', quiet=True)
-            
+
             # Verify the tar file was created
             try:
                 if not self.exists(tf):
                     raise Exception(f"Tar file is missing")
             except Exception as e:
                 raise Exception(f"Failed to verify tar file: {str(e)}")
-                
+
         except Exception as e:
             logging.error(f"Failed to create tar file: {str(e)}")
             raise
@@ -472,12 +472,12 @@ class Host:
         except:
             pass
         os.chdir(dest)
-        
+
         # Ensure proper path format for SFTP
         remote_path = tf.replace("\\", "/")
         if remote_path.startswith("//"):
             remote_path = remote_path[1:]  # Remove one leading slash if there are two
-        
+
         logging.debug(f"Attempting to download from remote path: {remote_path}")
         try:
             # Check if file exists by trying to stat it
@@ -485,7 +485,7 @@ class Host:
                 self.connection.sftp().stat(remote_path)
             except FileNotFoundError:
                 raise FileNotFoundError(f"Remote file not found: {remote_path}")
-            
+
             self.connection.get(remote_path)
         except Exception as e:
             logging.error(f"Download failed for {remote_path}: {str(e)}")

--- a/sisyphus/host.py
+++ b/sisyphus/host.py
@@ -429,21 +429,21 @@ class Host:
         # Create a tarball containing either just packages or the whole build directory
         try:
             if all:
-                result = self.run(f"cd {self.sisyphus_dir} && cd .. && tar -cf {tf} sisyphus")
+                self.run(f"cd {self.sisyphus_dir} && cd .. && tar -cf {tf} sisyphus")
             else:
                 if self.type == LINUX_TYPE:
-                    result = self.run(f"cd {builddir} && tar -cf {tf} {self.pkgdir}/*.conda {self.pkgdir}/*.tar.bz2 2>/dev/null || true")
+                    self.run(f"cd {builddir} && tar -cf {tf} {self.pkgdir}/*.conda {self.pkgdir}/*.tar.bz2 2>/dev/null || true")
                 elif self.type == WINDOWS_TYPE:
                     # First get the list of files - make sure we're in builddir first
                     files = self.run(f'cd {builddir} && dir /b /s {self.pkgdir}\\*.conda {self.pkgdir}\\*.tar.bz2 2>nul', quiet=True)
                     
                     if not files:
                         logging.warning("No package files found to tar")
-                        result = self.run(f'cd {builddir} && tar -cf "{tf}" --files-from NUL', quiet=True)
+                        self.run(f'cd {builddir} && tar -cf "{tf}" --files-from NUL', quiet=True)
                     else:
                         # Create file list - strip builddir prefix since we'll cd there
                         file_list = " ".join(f'"{f.replace(builddir + "\\", "")}"' for f in files.splitlines())
-                        result = self.run(f'cd {builddir} && tar -cf "{tf}" {file_list}', quiet=True)
+                        self.run(f'cd {builddir} && tar -cf "{tf}" {file_list}', quiet=True)
             
             # Verify the tar file was created
             try:

--- a/sisyphus/host.py
+++ b/sisyphus/host.py
@@ -447,15 +447,8 @@ class Host:
             
             # Verify the tar file was created
             try:
-                if self.type == WINDOWS_TYPE:
-                    size_check = self.run(f'cd {builddir} && dir "{tf}"')
-                else:
-                    # Linux uses -c format, macOS uses -f format
-                    size_check = self.run(f'stat -c%s "{tf}"')
-                
-                if not size_check:
+                if not self.exists(tf):
                     raise Exception(f"Tar file is missing")
-                    
             except Exception as e:
                 raise Exception(f"Failed to verify tar file: {str(e)}")
                 


### PR DESCRIPTION
This fixes the following crash below when doing sisyphus download using a windows host. This is mostly pathing fixes with some defensive code for the windows logic to confirm the tar command worked.

Confirmed on Linux and Windows hosts using OSX as the client.

```
(sisyphus)  ✘   ~/Code/sisyphus   main±  sisyphus download -H 34.239.150.243 -P llama.cpp -d builds
INFO Connected (version 2.0, client OpenSSH_for_Windows_8.0)
INFO Authentication (publickey) failed.
INFO Connected (version 2.0, client OpenSSH_for_Windows_8.0)
INFO Authentication (publickey) successful!
INFO '34.239.150.243' is a Windows host
INFO Build complete
INFO gguf-0.15.4575-py310haa95532_0.tar.bz2 already transmuted
INFO gguf-0.15.4575-py311haa95532_0.tar.bz2 already transmuted
INFO gguf-0.15.4575-py312haa95532_0.tar.bz2 already transmuted
INFO gguf-0.15.4575-py39haa95532_0.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cpu_v1_mkl_h4262f35_0.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cpu_v2_mkl_h0bdc4df_40.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cpu_v3_mkl_h393b973_50.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cuda124_v1_h6cbc5b3_200.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cuda124_v2_h16922bf_240.tar.bz2 already transmuted
INFO llama.cpp-0.0.4575-cuda124_v3_hf3fb316_250.tar.bz2 already transmuted
INFO llama.cpp-tools-0.0.4575-py310haa95532_0.tar.bz2 already transmuted
INFO llama.cpp-tools-0.0.4575-py311haa95532_0.tar.bz2 already transmuted
INFO llama.cpp-tools-0.0.4575-py312haa95532_0.tar.bz2 already transmuted
INFO llama.cpp-tools-0.0.4575-py39haa95532_0.tar.bz2 already transmuted
INFO Downloading package tarballs in '\sisyphus\llama.cpp\build\win-64'
INFO [chan 21] Opened sftp connection (server version 3)
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/sisyphus/bin/sisyphus", line 8, in <module>
    sys.exit(cli())
             ~~~^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/jesse/Code/sisyphus/sisyphus/main.py", line 171, in download
    h.download(package, destination, all)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jesse/Code/sisyphus/sisyphus/host.py", line 448, in download
    self.connection.get(tf.replace("\\", "/"))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/fabric/connection.py", line 897, in get
    return Transfer(self).get(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/fabric/transfer.py", line 170, in get
    self.sftp.get(remotepath=remote, localpath=local)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 840, in get
    size = self.getfo(
        remotepath,
    ...<3 lines>...
        max_concurrent_prefetch_requests,
    )
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 795, in getfo
    file_size = self.stat(remotepath).st_size
                ~~~~~~~~~^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 493, in stat
    t, msg = self._request(CMD_STAT, path)
             ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 857, in _request
    return self._read_response(num)
           ~~~~~~~~~~~~~~~~~~~^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 909, in _read_response
    self._convert_status(msg)
    ~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/opt/homebrew/anaconda3/envs/sisyphus/lib/python3.13/site-packages/paramiko/sftp_client.py", line 942, in _convert_status
    raise IOError(text)
OSError: Failure
```